### PR TITLE
Deployment changes that were used for v0.5.0b

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # README #
 
-Steps to deploy [`adage-server`](https://github.com/greenelab/adage-server) to
-Amazon's EC2 cloud. This uses [fabric](http://www.fabfile.org) to automate
-tasks.
+This repository captures the steps required to deploy
+[`adage-server`](https://github.com/greenelab/adage-server) to
+Amazon's EC2 cloud. This process uses [fabric](http://www.fabfile.org) to
+automate tasks.
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # README #
 
-Steps to deploy adage to Amazon's EC2 cloud. This uses fabric to automate tasks. Follow the commands in steps.sh putting in the relevant information where required.
+Steps to deploy [`adage-server`](https://github.com/greenelab/adage-server) to
+Amazon's EC2 cloud. This uses [fabric](http://www.fabfile.org) to automate
+tasks.
+
+## Usage ##
+
+Please follow the **Deployment Steps** found in the
+[README file for the `adage-server` repository](https://github.com/greenelab/adage-server#deployment-steps).

--- a/fabfile.py
+++ b/fabfile.py
@@ -22,7 +22,7 @@ from __future__ import with_statement
 import logging
 import os, sys
 import pprint
-from time import sleep
+import time
 from boto3.session import Session
 from fabric.api import put, get, run, sudo, execute, reboot
 from fabric.api import env, local, settings, hide, abort, task, runs_once
@@ -59,6 +59,12 @@ import config
 
 # Choose the configuration to use for the rest of this deployment from config.py
 CONFIG = config.CONFIG
+
+
+@task
+def v():
+    """ Turn on more verbose logging """
+    logging.basicConfig(level=logging.INFO)
 
 
 @task
@@ -115,7 +121,7 @@ def launch_ec2_instance():
     # this is a little hackish, but it ensures the next command will not
     # timeout because the server hasn't actually finished coming online yet...
     print("Waiting for instance to come online...")
-    sleep(45)
+    time.sleep(45)
     with settings(hide('running'), warn_only=True):
         # note: this is not actually a "reboot" but a "hostname" command
         execute(reboot, command='hostname', hosts=[
@@ -195,13 +201,17 @@ def install_system_packages():
     Install all python, postgres, elasticsearch, and other packages required to
     deploy and manage an Adage instance.
     """
+    # first, ensure we have latest versions of everything
     sudo('apt-get update')
+    sudo('apt-get -y -q upgrade')
+    sudo('apt-get -y -q dist-upgrade')
+    # now handle specific system packages we need
     execute(_install_elasticsearch)
     execute(_install_python_deps)
     execute(_install_postgres)
     sudo('apt-get -y -q install nodejs-legacy build-essential nginx npm '
-        'supervisor phantomjs')
-    sudo('npm -g install grunt-cli karma bower')
+        'supervisor')
+    sudo('npm -g install grunt-cli karma bower phantomjs-prebuilt')
 
 
 @task
@@ -309,6 +319,7 @@ def add_deploy_key():
     sudo('chown adage:adage /home/adage/.ssh/id_rsa')
 
 
+@task
 def add_known_hosts():
     """
     This command pre-populates the adage user's .ssh/known_hosts file so we
@@ -317,6 +328,7 @@ def add_known_hosts():
     """
     sudo('ssh-keyscan -t rsa github.com bitbucket.org > '
         '/home/adage/.ssh/known_hosts', user="adage")
+
 
 def create_deploy_keys():
     """
@@ -438,8 +450,8 @@ def configure_system():
     Configure all base system setup tasks we can do before setting up the
     adage user
     """
-    enable_unattended_updates()
     install_system_packages()
+    enable_unattended_updates()
     setup_elasticsearch()
 
 
@@ -486,6 +498,16 @@ def _deploy(hostlist):
     logging.info("Deploying to hostlist: [" + ','.join(hostlist) + "]")
     
     execute(configure_system, hosts=hostlist)
+    local('date')
+    # execute(reboot, hosts=hostlist)
+    with settings(warn_only=True):
+        print 'rebooting'
+        start_time = time.time()
+        execute(reboot, wait=1200, hosts=hostlist)
+        print 'reboot took: {} seconds'.format(time.time() - start_time)
+    local('date')
+    print("env.hosts: [" + ', '.join(env.hosts) + "]")
+    # run('uname -a')
     execute(configure_adage, hosts=hostlist)
 
     # now we use the connection info specified in CONFIG['os'] to connect
@@ -523,6 +545,15 @@ def deploy_dev():
     # _deploy switches to a different 'host_conn' so we need to reset here
     execute(adage_server.setup_host_conn, use_conn=CONFIG['host_conn'])
     execute(tweak_nginx_for_dev, hosts=env.hosts)
+
+
+@task
+def dropdb():
+    CONFIG = config.AWS_CONFIG
+    sqlstr = """echo "drop database {NAME};
+drop role {NAME};" """.format(**CONFIG['databases']['default'])
+    run(sqlstr + ' | psql --host={HOST} --username={USER}'.format(
+        sql=sqlstr, **CONFIG['dbmaster']))
 
 
 @task(alias='resume')

--- a/fabfile.py
+++ b/fabfile.py
@@ -413,7 +413,9 @@ def setup_supervisor():
     """
     put('files/supervisord/adage_super.conf',
         '/etc/supervisor/conf.d/adage_super.conf', use_sudo=True)
-    sudo('sudo /etc/init.d/supervisor restart')
+    # systemctl now used for services in Ubuntu 16.04
+    sudo('systemctl enable supervisor')
+    sudo('systemctl start supervisor')
 
 
 @task

--- a/files/upgrade/50unattended-upgrades
+++ b/files/upgrade/50unattended-upgrades
@@ -1,29 +1,61 @@
 // Automatically upgrade packages from these (origin, archive) pairs
 Unattended-Upgrade::Allowed-Origins {    
-    // ${distro_id} and ${distro_codename} will be automatically expanded
-    "${distro_id} stable";
-    "${distro_id} ${distro_codename}-security";
-    "${distro_id} ${distro_codename}-updates";
-//  "${distro_id} ${distro_codename}-proposed-updates";
+  // ${distro_id} and ${distro_codename} will be automatically expanded
+	"${distro_id}:${distro_codename}";
+	"${distro_id}:${distro_codename}-security";
+	"${distro_id}:${distro_codename}-updates";
+//	"${distro_id}:${distro_codename}-proposed";
+//	"${distro_id}:${distro_codename}-backports";
 };
 
 // List of packages to not update
 Unattended-Upgrade::Package-Blacklist {
-//  "libc6";
-//  "libc6-dev";
-//  "libc6-i686";
+//	"vim";
+//	"libc6";
+//	"libc6-dev";
+//	"libc6-i686";
 };
 
+// This option allows you to control if on a unclean dpkg exit
+// unattended-upgrades will automatically run
+//   dpkg --force-confold --configure -a
+// The default is true, to ensure updates keep getting installed
+//Unattended-Upgrade::AutoFixInterruptedDpkg "false";
+
+// Split the upgrade into the smallest possible chunks so that
+// they can be interrupted with SIGUSR1. This makes the upgrade
+// a bit slower but it has the benefit that shutdown while a upgrade
+// is running is possible (with a small delay)
+//Unattended-Upgrade::MinimalSteps "true";
+
+// Install all unattended-upgrades when the machine is shuting down
+// instead of doing it in the background while the machine is running
+// This will (obviously) make shutdown slower
+//Unattended-Upgrade::InstallOnShutdown "true";
+
 // Send email to this address for problems or packages upgrades
-// If empty or unset then no email is sent, make sure that you 
-// have a working mail setup on your system. The package mailx
-// must be installed or anything that provides /usr/bin/mail.
-//Unattended-Upgrade::Mail "root@localhost";
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+//Unattended-Upgrade::Mail "root";
+
+// Set this value to "true" to get emails only on errors. Default
+// is to always send a mail if Unattended-Upgrade::Mail is set
+//Unattended-Upgrade::MailOnlyOnError "true";
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
-// Automatically reboot *WITHOUT CONFIRMATION* if a 
-// the file /var/run/reboot-required is found after the upgrade 
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "true";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 70kb/sec
+//Acquire::http::Dl-Limit "70";


### PR DESCRIPTION
I have been using most of these changes for a while, but couldn't submit a PR on them because my
fork had become detached from greenelab/adage-deploy when that repo switched from private to
public.

This PR corrects that problem and will help me eliminate that orphaned repo.
