### PR TITLE
Transforming .hgignore file (unused)into .gitignore file, modifying the syntax to work properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-~$
+*~
 authorized_keys
 deploy_rsa
 deploy_rsa.pub
-.pyc$
+*.pyc


### PR DESCRIPTION
Really small PR  - While making changes to the tribe-ec2-deploy repo, I noticed that this repository still had the .hgignore file, so I just switched made the necessary changes.